### PR TITLE
libgralloc: Fix refresh rate calculation

### DIFF
--- a/exynos4/hal/libgralloc_ump/framebuffer_device.cpp
+++ b/exynos4/hal/libgralloc_ump/framebuffer_device.cpp
@@ -263,8 +263,8 @@ int init_frame_buffer_locked(struct private_module_t* module)
 
     int refreshRate = 1000000000000000LLU /
     (
-        uint64_t( info.upper_margin + info.lower_margin + info.yres )
-        * ( info.left_margin  + info.right_margin + info.xres )
+        uint64_t( info.upper_margin + info.lower_margin + info.vsync_len + info.yres )
+        * ( info.left_margin  + info.right_margin + info.hsync_len + info.xres )
         * info.pixclock
     );
 


### PR DESCRIPTION
Calculated refresh rate can be 3% off
Reference: https://code.google.com/p/android/issues/detail?id=69391

Change-Id: I3b4efefcc0aef695ba48abdfb61f6d38b9d0a79c